### PR TITLE
db column for password_hash to small

### DIFF
--- a/api.py
+++ b/api.py
@@ -22,7 +22,7 @@ class User(db.Model):
     __tablename__ = 'users'
     id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(32), index=True)
-    password_hash = db.Column(db.String(64))
+    password_hash = db.Column(db.String(128))
 
     def hash_password(self, password):
         self.password_hash = generate_password_hash(password)


### PR DESCRIPTION
Thanks for your tutorial.
The size of the database field for the hash is too small. The hash is 64 bytes, but before that there is the method and the salt. For me that's 94 bytes.
'pbkdf2:sha256:150000$49dV4TkV$7fae72c74524d30be8baa0e137f53e1f5e01a34b811793f455586c55dd9f1745'