### PR TITLE
Upgrade markupsafe from 1.0 to 1.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-HTTPAuth==4.0.0
 Flask-SQLAlchemy==2.4.1
 itsdangerous==0.24
 Jinja2==2.11.2
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 PyJWT==1.7.1
 SQLAlchemy==1.1.11
 Werkzeug==1.0.1


### PR DESCRIPTION
The following error occurs on `pip install -r requirements.txt` while using Python 3.7.9. 

I found the solution here: https://github.com/pallets/markupsafe/issues/116 and updated MarkupSafe from 1.0 to 1.1.1

    ERROR: Command errored out with exit status 1:
     command: /Users/chaynorhsiao/Code/REST-auth/venv/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/5v/cz5lkd_15fl759j_38vjsthr0000gn/T/pip-install-rt5k3gwz/markupsafe/setup.py'"'"'; __file__='"'"'/private/var/folders/5v/cz5lkd_15fl759j_38vjsthr0000gn/T/pip-install-rt5k3gwz/markupsafe/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /private/var/folders/5v/cz5lkd_15fl759j_38vjsthr0000gn/T/pip-pip-egg-info-ivlzia0j
         cwd: /private/var/folders/5v/cz5lkd_15fl759j_38vjsthr0000gn/T/pip-install-rt5k3gwz/markupsafe/
    Complete output (5 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/5v/cz5lkd_15fl759j_38vjsthr0000gn/T/pip-install-rt5k3gwz/markupsafe/setup.py", line 6, in <module>
        from setuptools import setup, Extension, Feature
    ImportError: cannot import name 'Feature' from 'setuptools'
